### PR TITLE
Added general solution for HTML detection

### DIFF
--- a/src/main/java/nl/andrewl/emaildatasetbrowser/util/HTMLHelper.java
+++ b/src/main/java/nl/andrewl/emaildatasetbrowser/util/HTMLHelper.java
@@ -1,0 +1,25 @@
+package nl.andrewl.emaildatasetbrowser.util;
+
+import java.util.regex.Pattern;
+
+public final class HTMLHelper {
+
+    public static final String TAG_START = "<\\w+((\\s+\\w+(\\s*=\\s*(?:\".*?\"|'.*?'|[^'\">\\s]+))?)+\\s*|\\s*)>";
+    public static final String TAG_END = "</\\w+>";
+    public static final String TAG_SELF_CLOSING = "<\\w+((\\s+\\w+(\\s*=\\s*(?:\".*?\"|'.*?'|[^'\">\\s]+))?)+\\s*|\\s*)/>";
+    public static final String HTML_ENTITY = "&[a-zA-Z][a-zA-Z0-9]+;";
+    public static final Pattern htmlPattern = Pattern
+            .compile("(" + TAG_START + ".*" + TAG_END + ")|(" + TAG_SELF_CLOSING + ")|(" + HTML_ENTITY + ")",
+                    Pattern.DOTALL);
+
+    private HTMLHelper() {
+    }
+
+    public static boolean isHtml(String htmlString) {
+        boolean isHTML = false;
+        if (htmlString != null) {
+            isHTML = htmlPattern.matcher(htmlString).find();
+        }
+        return isHTML;
+    }
+}

--- a/src/main/java/nl/andrewl/emaildatasetbrowser/view/email/EmailBodyPanel.java
+++ b/src/main/java/nl/andrewl/emaildatasetbrowser/view/email/EmailBodyPanel.java
@@ -1,9 +1,14 @@
 package nl.andrewl.emaildatasetbrowser.view.email;
 
-import nl.andrewl.email_indexer.data.EmailEntry;
+import java.awt.BorderLayout;
+import java.awt.Font;
 
-import javax.swing.*;
-import java.awt.*;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextPane;
+
+import nl.andrewl.email_indexer.data.EmailEntry;
+import nl.andrewl.emaildatasetbrowser.util.HTMLHelper;
 
 /**
  * A panel containing some basic components for viewing the body of an email.
@@ -22,7 +27,7 @@ public class EmailBodyPanel extends JPanel implements EmailViewListener {
 
 	private void setEmail(EmailEntry email) {
 		if (email != null) {
-			if (email.body().startsWith("<html>")) {
+			if (HTMLHelper.isHtml(email.body())) {
 				textPane.setContentType("text/html");
 			} else {
 				textPane.setContentType("text/plain");


### PR DESCRIPTION
Whilst browsing the engine, I noticed that a bunch of mails containing HTML remained unrecognized (e.g. because they started with ``<!DOCTYPE html>`` instead of ``<html>``), making them effectively unreadable. I took this blog's solution ([link](https://denofdevelopers.com/how-to-detect-if-string-is-html-or-not-in-android/)) and added it into the tool. The build still works and as far as I'm aware all HTML is loaded properly now. 