### PR TITLE
Increased the tag color's contrast

### DIFF
--- a/src/main/java/nl/andrewl/emaildatasetbrowser/util/ColorHelper.java
+++ b/src/main/java/nl/andrewl/emaildatasetbrowser/util/ColorHelper.java
@@ -1,0 +1,43 @@
+package nl.andrewl.emaildatasetbrowser.util;
+
+import java.awt.Color;
+import java.util.Random;
+
+public class ColorHelper {
+    public static final Random random = new Random();
+
+    private static final Color BG_COLOR = new Color(70, 73, 75);
+    private static final double CONTRAST_THRESHOLD = 2.25F;
+
+    /**
+     * Returns a random color that has high contrast with the background.
+     */
+    public static Color getColor(String text) {
+        random.setSeed(text.hashCode());
+        Color color = null;
+        do {
+            float hue = random.nextFloat();
+            float saturation = random.nextFloat() / 4f + 0.75f;
+            float luminance = 0.9f;
+            color = Color.getHSBColor(hue, saturation, luminance);
+        } while (!hasEnoughContrast(color, BG_COLOR));
+        return color;
+    }
+
+    /**
+     * Calculates the luminosity contrast between two colors.
+     * Returns whether the contrast between these two is high enough.
+     */
+    private static boolean hasEnoughContrast(Color colorA, Color colorB) {
+        double L1 = 0.2126 * Math.pow((double) colorA.getRed() / 255f, 2.2) +
+                0.7152 * Math.pow((double) colorA.getGreen() / 255f, 2.2) +
+                0.0722 * Math.pow((double) colorA.getBlue() / 255f, 2.2);
+        double L2 = 0.2126 * Math.pow((double) colorB.getRed() / 255f, 2.2) +
+                0.7152 * Math.pow((double) colorB.getGreen() / 255f, 2.2) +
+                0.0722 * Math.pow((double) colorB.getBlue() / 255f, 2.2);
+        double luminosityContrast = L1 > L2
+                ? (L1 + 0.05) / (L2 + 0.05)
+                : (L2 + 0.05) / (L1 + 0.05);
+        return luminosityContrast > CONTRAST_THRESHOLD;
+    }
+}

--- a/src/main/java/nl/andrewl/emaildatasetbrowser/view/SwingUtils.java
+++ b/src/main/java/nl/andrewl/emaildatasetbrowser/view/SwingUtils.java
@@ -2,12 +2,12 @@ package nl.andrewl.emaildatasetbrowser.view;
 
 import javax.swing.*;
 import javax.swing.text.JTextComponent;
+
 import java.awt.*;
-import java.util.Random;
 
 public final class SwingUtils {
-	public static final Random random = new Random();
-	private SwingUtils() {}
+	private SwingUtils() {
+	}
 
 	public static void setAllButtonsEnabled(Container c, boolean enabled) {
 		for (var component : c.getComponents()) {
@@ -27,22 +27,15 @@ public final class SwingUtils {
 
 	@SuppressWarnings("unchecked")
 	public static <T extends Component> T findFirstInstance(Container c, Class<T> type) {
-		for (var component: c.getComponents()) {
+		for (var component : c.getComponents()) {
 			if (component.getClass().equals(type)) {
 				return (T) component;
 			} else if (component instanceof Container nested) {
 				T result = findFirstInstance(nested, type);
-				if (result != null) return result;
+				if (result != null)
+					return result;
 			}
 		}
 		return null;
-	}
-
-	public static Color getColor(String text) {
-		random.setSeed(text.hashCode());
-		float hue = random.nextFloat();
-		float saturation = random.nextFloat() / 4f + 0.75f;
-		float luminance = 0.9f;
-		return Color.getHSBColor(hue, saturation, luminance);
 	}
 }

--- a/src/main/java/nl/andrewl/emaildatasetbrowser/view/email/EmailNavigationPanel.java
+++ b/src/main/java/nl/andrewl/emaildatasetbrowser/view/email/EmailNavigationPanel.java
@@ -1,7 +1,7 @@
 package nl.andrewl.emaildatasetbrowser.view.email;
 
 import nl.andrewl.email_indexer.data.EmailEntry;
-import nl.andrewl.emaildatasetbrowser.view.SwingUtils;
+import nl.andrewl.emaildatasetbrowser.util.ColorHelper;
 
 import javax.swing.*;
 import java.awt.*;
@@ -79,7 +79,7 @@ public class EmailNavigationPanel extends JPanel {
 			var email = navigationStack.get(i);
 			JButton button = new JButton(email.subject().substring(0, Math.min(email.subject().length(), 24)));
 			button.setToolTipText("Subject: %s\nFrom: %s\nId: %s".formatted(email.subject(), email.sentFrom(), email.messageId()));
-			button.setForeground(SwingUtils.getColor(email.messageId()));
+			button.setForeground(ColorHelper.getColor(email.messageId()));
 			final int idx = i;
 			button.addActionListener(e -> {
 				for (int k = navigationStack.size() - 1; k > idx; k--) navigationStack.pop();

--- a/src/main/java/nl/andrewl/emaildatasetbrowser/view/email/TagListCellRenderer.java
+++ b/src/main/java/nl/andrewl/emaildatasetbrowser/view/email/TagListCellRenderer.java
@@ -1,6 +1,6 @@
 package nl.andrewl.emaildatasetbrowser.view.email;
 
-import nl.andrewl.emaildatasetbrowser.view.SwingUtils;
+import nl.andrewl.emaildatasetbrowser.util.ColorHelper;
 
 import javax.swing.*;
 import java.awt.*;
@@ -19,7 +19,7 @@ public class TagListCellRenderer implements ListCellRenderer<String> {
 
 	@Override
 	public Component getListCellRendererComponent(JList<? extends String> list, String value, int index, boolean isSelected, boolean cellHasFocus) {
-		Color foregroundColor = SwingUtils.getColor(value);
+		Color foregroundColor = ColorHelper.getColor(value);
 
 		label.setText(value);
 		label.setForeground(foregroundColor);


### PR DESCRIPTION
Some of the colors that were selected for the tags had very low contrast. I updated the color utility to test the luminosity contrast and pick a new color if the contrast is too low. As far as I'm aware, there is no noticeable performance overhead.
I moved it out of the ``SwingUtils`` else that class would become too incoherent.